### PR TITLE
ipfs to boxo migration

### DIFF
--- a/coreapi.go
+++ b/coreapi.go
@@ -4,13 +4,14 @@ package iface
 
 import (
 	"context"
+
 	path "github.com/bittorrent/interface-go-btfs-core/path"
 
 	"github.com/bittorrent/interface-go-btfs-core/options"
 
 	ipld "github.com/ipfs/go-ipld-format"
 
-	ipfspath "github.com/ipfs/go-path"
+	ipfspath "github.com/ipfs/boxo/path"
 )
 
 // CoreAPI defines an unified interface to IPFS for Go programs

--- a/options/pin.go
+++ b/options/pin.go
@@ -11,7 +11,8 @@ type PinAddSettings struct {
 
 // PinLsSettings represent the settings for PinAPI.Ls
 type PinLsSettings struct {
-	Type string
+	Type     string
+	Detailed bool
 }
 
 // PinIsPinnedSettings represent the settings for PinAPI.IsPinned
@@ -169,11 +170,11 @@ func (pinLsOpts) Indirect() PinLsOption {
 // type.
 //
 // Supported values:
-// * "direct" - directly pinned objects
-// * "recursive" - roots of recursive pins
-// * "indirect" - indirectly pinned objects (referenced by recursively pinned
-//    objects)
-// * "all" - all pinned objects (default)
+//   - "direct" - directly pinned objects
+//   - "recursive" - roots of recursive pins
+//   - "indirect" - indirectly pinned objects (referenced by recursively pinned
+//     objects)
+//   - "all" - all pinned objects (default)
 func (pinLsOpts) Type(typeStr string) (PinLsOption, error) {
 	switch typeStr {
 	case "all", "direct", "indirect", "recursive":
@@ -187,11 +188,11 @@ func (pinLsOpts) Type(typeStr string) (PinLsOption, error) {
 // be returned
 //
 // Supported values:
-// * "direct" - directly pinned objects
-// * "recursive" - roots of recursive pins
-// * "indirect" - indirectly pinned objects (referenced by recursively pinned
-//    objects)
-// * "all" - all pinned objects (default)
+//   - "direct" - directly pinned objects
+//   - "recursive" - roots of recursive pins
+//   - "indirect" - indirectly pinned objects (referenced by recursively pinned
+//     objects)
+//   - "all" - all pinned objects (default)
 func (pinLsOpts) pinType(t string) PinLsOption {
 	return func(settings *PinLsSettings) error {
 		settings.Type = t
@@ -229,11 +230,11 @@ func (pinIsPinnedOpts) Indirect() PinIsPinnedOption {
 // type.
 //
 // Supported values:
-// * "direct" - directly pinned objects
-// * "recursive" - roots of recursive pins
-// * "indirect" - indirectly pinned objects (referenced by recursively pinned
-//    objects)
-// * "all" - all pinned objects (default)
+//   - "direct" - directly pinned objects
+//   - "recursive" - roots of recursive pins
+//   - "indirect" - indirectly pinned objects (referenced by recursively pinned
+//     objects)
+//   - "all" - all pinned objects (default)
 func (pinIsPinnedOpts) Type(typeStr string) (PinIsPinnedOption, error) {
 	switch typeStr {
 	case "all", "direct", "indirect", "recursive":
@@ -247,11 +248,11 @@ func (pinIsPinnedOpts) Type(typeStr string) (PinIsPinnedOption, error) {
 // pin is expected to be, speeding up the research.
 //
 // Supported values:
-// * "direct" - directly pinned objects
-// * "recursive" - roots of recursive pins
-// * "indirect" - indirectly pinned objects (referenced by recursively pinned
-//    objects)
-// * "all" - all pinned objects (default)
+//   - "direct" - directly pinned objects
+//   - "recursive" - roots of recursive pins
+//   - "indirect" - indirectly pinned objects (referenced by recursively pinned
+//     objects)
+//   - "all" - all pinned objects (default)
 func (pinIsPinnedOpts) pinType(t string) PinIsPinnedOption {
 	return func(settings *PinIsPinnedSettings) error {
 		settings.WithType = t
@@ -307,11 +308,11 @@ func (pinOpts) RmForce(force bool) PinRmOption {
 // be returned
 //
 // Supported values:
-// * "direct" - directly pinned objects
-// * "recursive" - roots of recursive pins
-// * "indirect" - indirectly pinned objects (referenced by recursively pinned
-//    objects)
-// * "all" - all pinned objects (default)
+//   - "direct" - directly pinned objects
+//   - "recursive" - roots of recursive pins
+//   - "indirect" - indirectly pinned objects (referenced by recursively pinned
+//     objects)
+//   - "all" - all pinned objects (default)
 func (pinOpts) pinType(t string) PinLsOption {
 	return func(settings *PinLsSettings) error {
 		settings.Type = t
@@ -327,4 +328,3 @@ func (pinOpts) Unpin(unpin bool) PinUpdateOption {
 		return nil
 	}
 }
-

--- a/options/unixfs.go
+++ b/options/unixfs.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 	cid "github.com/ipfs/go-cid"
-	dag "github.com/ipfs/go-merkledag"
 	mh "github.com/multiformats/go-multihash"
 )
 

--- a/path/path.go
+++ b/path/path.go
@@ -3,8 +3,8 @@ package path
 import (
 	"strings"
 
+	ipfspath "github.com/ipfs/boxo/path"
 	cid "github.com/ipfs/go-cid"
-	ipfspath "github.com/ipfs/go-path"
 )
 
 // Path is a generic wrapper for paths used in the API. A path can be resolved
@@ -141,7 +141,7 @@ func IpldPath(c cid.Cid) Resolved {
 
 // New parses string path to a Path
 func New(p string) Path {
-	if pp, err := ipfspath.ParsePath(p); err == nil {
+	if pp, err := ipfspath.NewPath(p); err == nil {
 		p = pp.String()
 	}
 
@@ -165,7 +165,7 @@ func (p *path) String() string {
 }
 
 func (p *path) Namespace() string {
-	ip, err := ipfspath.ParsePath(p.path)
+	ip, err := ipfspath.NewPath(p.path)
 	if err != nil {
 		return ""
 	}
@@ -182,7 +182,7 @@ func (p *path) Mutable() bool {
 }
 
 func (p *path) IsValid() error {
-	_, err := ipfspath.ParsePath(p.path)
+	_, err := ipfspath.NewPath(p.path)
 	return err
 }
 

--- a/pin.go
+++ b/pin.go
@@ -2,6 +2,7 @@ package iface
 
 import (
 	"context"
+
 	"github.com/bittorrent/interface-go-btfs-core/options"
 	path "github.com/bittorrent/interface-go-btfs-core/path"
 )


### PR DESCRIPTION
As part of the IPFS SDK dependencies migration to boxo, this update is necessary to move to boxo SDK for BTFS. I'll be doing other Pull Request in several BTFS repos to safely move to boxo and support newer golang releases